### PR TITLE
Fix Python Wrapping

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,11 +4,16 @@ set(Module_SRCS
   vtkFrenetSerretFrame.cxx
   vtkSplineDrivenImageSlicer.cxx  
 )
+set(headers
+  vtkFrenetSerretFrame.h
+  vtkSplineDrivenImageSlicer.h
+)
 
 if (VTK_VERSION VERSION_LESS "8.90.0")
-  vtk_module_library(SplineDrivenImageSlicer ${Module_SRCS})
+  vtk_module_library(vtkSplineDrivenImageSlicer ${Module_SRCS})
 else()
   vtk_module_add_module(VTK::SplineDrivenImageSlicer
     SOURCES ${Module_SRCS}
-    )
+    HEADERS ${headers}
+  )
 endif()

--- a/module.cmake
+++ b/module.cmake
@@ -1,6 +1,6 @@
 set(DOCUMENTATION "A Spline Driven Reslice Algorithm as described in the VTK Journal Article at http://www.vtkjournal.org/browse/publication/838 .")
 
-vtk_module( SplineDrivenImageSlicer
+vtk_module(vtkSplineDrivenImageSlicer
   DESCRIPTION
     "${DOCUMENTATION}"
   DEPENDS

--- a/vtk.module
+++ b/vtk.module
@@ -1,7 +1,7 @@
 NAME
   VTK::SplineDrivenImageSlicer
 LIBRARY_NAME
-  SplineDrivenImageSlicer
+  vtkSplineDrivenImageSlicer
 DEPENDS
   VTK::CommonCore
   VTK::FiltersCore

--- a/vtkFrenetSerretFrame.h
+++ b/vtkFrenetSerretFrame.h
@@ -38,10 +38,10 @@
 #ifndef vtkFrenetSerretFrame_h
 #define vtkFrenetSerretFrame_h
 
-#include "SplineDrivenImageSlicerModule.h" // For export macro
+#include "vtkSplineDrivenImageSlicerModule.h" // For export macro
 #include "vtkPolyDataAlgorithm.h"
 
-class SPLINEDRIVENIMAGESLICER_EXPORT vtkFrenetSerretFrame : public vtkPolyDataAlgorithm
+class VTKSPLINEDRIVENIMAGESLICER_EXPORT vtkFrenetSerretFrame : public vtkPolyDataAlgorithm
 {
 public:
   vtkTypeMacro(vtkFrenetSerretFrame,vtkPolyDataAlgorithm);

--- a/vtkSplineDrivenImageSlicer.h
+++ b/vtkSplineDrivenImageSlicer.h
@@ -46,9 +46,9 @@
 class vtkFrenetSerretFrame;
 class vtkImageReslice;
 
-#include "SplineDrivenImageSlicerModule.h" // For export macro
+#include "vtkSplineDrivenImageSlicerModule.h" // For export macro
 
-class SPLINEDRIVENIMAGESLICER_EXPORT vtkSplineDrivenImageSlicer : public vtkImageAlgorithm
+class VTKSPLINEDRIVENIMAGESLICER_EXPORT vtkSplineDrivenImageSlicer : public vtkImageAlgorithm
 {
 public:
   vtkTypeMacro(vtkSplineDrivenImageSlicer,vtkImageAlgorithm);


### PR DESCRIPTION
In VTK 9.1.0 the python classes were not built properly and could not be imported in `vtkmodules.all`. 

Also the 'vtk' prefix was missing.